### PR TITLE
fix: find_one return wrong type

### DIFF
--- a/guest-js/wrapper.ts
+++ b/guest-js/wrapper.ts
@@ -132,7 +132,7 @@ export class Collection<T extends object = any> {
     ): Promise<Document<T> | null> {
         this.check();
         const result = await find_one(this.database, this.name, query);
-        return result.success ? this.makeDocuments<T>(result.data)[0] : null;
+        return result.success ? this.makeDocuments<T>(...result.data)[0] : null;
     }
 
     public async all(sort?: any): Promise<Document<T>[]> {


### PR DESCRIPTION
fix #2 [BUG] Incorrect Return Type for find_one Function